### PR TITLE
Fix small problems that prevent this package to build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "rpkt-dpdk",
   "rpkt-time",
   "examples",
+  "benches",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-  
+#rpkt
+
+
+### Testing
+
+To run tests successfully, dev-packages for nettle, libsystemd, bz2, zstd, lz4 and acl should be installed.
+
+On debian-compatible systems you can install them by running:
+```
+apt install nettle-dev libsystemd-dev libbz2-dev libzstd-dev liblz4-dev libacl1-dev
+```

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,14 +5,14 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-criterion = "0.3"
-smoltcp = "0.8"
-arrayvec = "0.7.2"
+criterion = "0.5.1"
+smoltcp = "0.8.2"
+arrayvec = "0.7.4"
 bytes = "1"
 ctrlc = { version = "3.0", features = ["termination"]}
-run-time = {path = "../run-time", package = "run-time"}
-run-dpdk = {path = "../run-dpdk", package = "run-dpdk"}
-run-packet = {path = "../run-packet", package = "run-packet"}
+rpkt-time = {path = "../rpkt-time", package = "rpkt-time"}
+rpkt-dpdk = {path = "../rpkt-dpdk", package = "rpkt-dpdk"}
+rpkt = {path = "../rpkt", package = "rpkt"}
 
 [[bench]]
 name = "pbuf_parse"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,7 @@ arrayvec = "0.7.4"
 bytes = "1"
 ctrlc = { version = "3.0", features = ["termination"]}
 rpkt-time = {path = "../rpkt-time", package = "rpkt-time"}
-rpkt-dpdk = {path = "../rpkt-dpdk", package = "rpkt-dpdk"}
+rpkt-dpdk = {path = "../rpkt-dpdk", package = "rpkt-dpdk", features = ["multiseg"]}
 rpkt = {path = "../rpkt", package = "rpkt"}
 
 [[bench]]

--- a/benches/dpdk/cursor_build.rs
+++ b/benches/dpdk/cursor_build.rs
@@ -1,11 +1,11 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::CursorMut;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::CursorMut;
 
 fn batched_build(batch: &mut ArrayVec<Mbuf, 32>, payload_len: usize) {
     for mut mbuf in batch.drain(..) {

--- a/benches/dpdk/cursor_fwd.rs
+++ b/benches/dpdk/cursor_fwd.rs
@@ -1,10 +1,10 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::CursorMut;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::CursorMut;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/benches/dpdk/cursor_new.rs
+++ b/benches/dpdk/cursor_new.rs
@@ -1,11 +1,11 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::Cursor;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::Cursor;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/benches/dpdk/cursor_new.rs
+++ b/benches/dpdk/cursor_new.rs
@@ -22,14 +22,14 @@ fn batched_l3(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Cursor::new(mbuf.data());
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.cursor_payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
-        assert!(ippkt.source_ip() == Ipv4Addr([192, 168, 29, 58]));
-        assert!(ippkt.dest_ip() == Ipv4Addr([192, 168, 29, 160]));
-        assert!(ippkt.checksum() == 0x0000);
-        assert!(ippkt.ident() == 0x5c65);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
+        assert_eq!(ippkt.source_ip(), Ipv4Addr([192, 168, 29, 58]));
+        assert_eq!(ippkt.dest_ip(), Ipv4Addr([192, 168, 29, 160]));
+        assert_eq!(ippkt.checksum(), 0x0000);
+        assert_eq!(ippkt.ident(), 0x5c65);
     }
 }
 
@@ -38,16 +38,16 @@ fn batched_l4(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Cursor::new(mbuf.data());
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.cursor_payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse(ippkt.cursor_payload()).unwrap();
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
-        assert!(udppkt.checksum() == 0xbc86);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
+        assert_eq!(udppkt.checksum(), 0xbc86);
     }
 }
 
@@ -56,21 +56,21 @@ fn batched_app(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Cursor::new(mbuf.data());
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.cursor_payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse(ippkt.cursor_payload()).unwrap();
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
 
         let payload = udppkt.cursor_payload();
 
         let mut b = [0; 66];
         (&mut b[..]).copy_from_slice(payload.chunk());
-        assert!(b[0..66] == FRAME_BYTES[42..108]);
+        assert_eq!(b[0..66], FRAME_BYTES[42..108]);
     }
 }
 

--- a/benches/dpdk/cursor_parse.rs
+++ b/benches/dpdk/cursor_parse.rs
@@ -1,11 +1,11 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::Cursor;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::Cursor;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/benches/dpdk/cursor_parse.rs
+++ b/benches/dpdk/cursor_parse.rs
@@ -22,14 +22,14 @@ fn batched_l3(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Cursor::new(mbuf.data());
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
-        assert!(ippkt.source_ip() == Ipv4Addr([192, 168, 29, 58]));
-        assert!(ippkt.dest_ip() == Ipv4Addr([192, 168, 29, 160]));
-        assert!(ippkt.checksum() == 0x0000);
-        assert!(ippkt.ident() == 0x5c65);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
+        assert_eq!(ippkt.source_ip(), Ipv4Addr([192, 168, 29, 58]));
+        assert_eq!(ippkt.dest_ip(), Ipv4Addr([192, 168, 29, 160]));
+        assert_eq!(ippkt.checksum(), 0x0000);
+        assert_eq!(ippkt.ident(), 0x5c65);
     }
 }
 
@@ -38,16 +38,16 @@ fn batched_l4(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Cursor::new(mbuf.data());
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse(ippkt.payload()).unwrap();
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
-        assert!(udppkt.checksum() == 0xbc86);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
+        assert_eq!(udppkt.checksum(), 0xbc86);
     }
 }
 
@@ -56,21 +56,21 @@ fn batched_app(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Cursor::new(mbuf.data());
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse(ippkt.payload()).unwrap();
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
 
         let payload = udppkt.payload();
 
         let mut b = [0; 66];
         (&mut b[..]).copy_from_slice(payload.chunk());
-        assert!(b[0..66] == FRAME_BYTES[42..108]);
+        assert_eq!(b[0..66], FRAME_BYTES[42..108]);
     }
 }
 

--- a/benches/dpdk/cursor_parse_coexist.rs
+++ b/benches/dpdk/cursor_parse_coexist.rs
@@ -1,10 +1,10 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Cursor;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Cursor;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/benches/dpdk/cursor_parse_coexist.rs
+++ b/benches/dpdk/cursor_parse_coexist.rs
@@ -23,12 +23,12 @@ fn batched_l4(batch: &mut ArrayVec<Mbuf, 32>) {
         if let Ok(ethpkt) = EtherPacket::parse(buf) {
             if let Ok(ippkt) = Ipv4Packet::parse(ethpkt.cursor_payload()) {
                 if let Ok(udppkt) = UdpPacket::parse(ippkt.cursor_payload()) {
-                    assert!(ethpkt.ethertype() == EtherType::IPV4);
-                    assert!(ippkt.protocol() == IpProtocol::UDP);
-                    assert!(udppkt.source_port() == 60376);
-                    assert!(udppkt.dest_port() == 161);
-                    assert!(udppkt.packet_len() == 74);
-                    assert!(udppkt.checksum() == 0xbc86);
+                    assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
+                    assert_eq!(ippkt.protocol(), IpProtocol::UDP);
+                    assert_eq!(udppkt.source_port(), 60376);
+                    assert_eq!(udppkt.dest_port(), 161);
+                    assert_eq!(udppkt.packet_len(), 74);
+                    assert_eq!(udppkt.checksum(), 0xbc86);
                 } else {
                     panic!();
                 }

--- a/benches/dpdk/cursor_parse_unchecked.rs
+++ b/benches/dpdk/cursor_parse_unchecked.rs
@@ -1,11 +1,11 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::Cursor;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::Cursor;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/benches/dpdk/cursor_parse_unchecked.rs
+++ b/benches/dpdk/cursor_parse_unchecked.rs
@@ -23,14 +23,14 @@ fn batched_l3(batch: &mut ArrayVec<Mbuf, 32>) {
         assert!(buf.chunk().len() >= 64);
 
         let ethpkt = EtherPacket::parse_unchecked(buf);
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse_unchecked(ethpkt.payload());
-        assert!(ippkt.protocol() == IpProtocol::UDP);
-        assert!(ippkt.source_ip() == Ipv4Addr([192, 168, 29, 58]));
-        assert!(ippkt.dest_ip() == Ipv4Addr([192, 168, 29, 160]));
-        assert!(ippkt.checksum() == 0x0000);
-        assert!(ippkt.ident() == 0x5c65);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
+        assert_eq!(ippkt.source_ip(), Ipv4Addr([192, 168, 29, 58]));
+        assert_eq!(ippkt.dest_ip(), Ipv4Addr([192, 168, 29, 160]));
+        assert_eq!(ippkt.checksum(), 0x0000);
+        assert_eq!(ippkt.ident(), 0x5c65);
     }
 }
 
@@ -40,16 +40,16 @@ fn batched_l4(batch: &mut ArrayVec<Mbuf, 32>) {
         // assert!(buf.chunk().len() >= 64);
 
         let ethpkt = EtherPacket::parse_unchecked(buf);
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse_unchecked(ethpkt.payload());
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse_unchecked(ippkt.payload());
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
-        assert!(udppkt.checksum() == 0xbc86);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
+        assert_eq!(udppkt.checksum(), 0xbc86);
     }
 }
 
@@ -59,21 +59,21 @@ fn batched_app(batch: &mut ArrayVec<Mbuf, 32>) {
         // assert!(buf.chunk().len() >= 64);
 
         let ethpkt = EtherPacket::parse_unchecked(buf);
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse_unchecked(ethpkt.payload());
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse_unchecked(ippkt.payload());
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
 
         let payload = udppkt.payload();
 
         let mut b = [0; 66];
         (&mut b[..]).copy_from_slice(payload.chunk());
-        assert!(b[0..66] == FRAME_BYTES[42..108]);
+        assert_eq!(b[0..66], FRAME_BYTES[42..108]);
     }
 }
 

--- a/benches/dpdk/pbuf_build.rs
+++ b/benches/dpdk/pbuf_build.rs
@@ -1,10 +1,10 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
 
 fn batched_build(batch: &mut ArrayVec<Mbuf, 32>, payload_len: usize) {
     for mut mbuf in batch.drain(..) {

--- a/benches/dpdk/pbuf_parse.rs
+++ b/benches/dpdk/pbuf_parse.rs
@@ -21,14 +21,14 @@ fn batched_l3(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Pbuf::new(mbuf);
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
-        assert!(ippkt.source_ip() == Ipv4Addr([192, 168, 29, 58]));
-        assert!(ippkt.dest_ip() == Ipv4Addr([192, 168, 29, 160]));
-        assert!(ippkt.checksum() == 0x0000);
-        assert!(ippkt.ident() == 0x5c65);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
+        assert_eq!(ippkt.source_ip(), Ipv4Addr([192, 168, 29, 58]));
+        assert_eq!(ippkt.dest_ip(), Ipv4Addr([192, 168, 29, 160]));
+        assert_eq!(ippkt.checksum(), 0x0000);
+        assert_eq!(ippkt.ident(), 0x5c65);
     }
 }
 
@@ -37,16 +37,16 @@ fn batched_l4(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Pbuf::new(mbuf);
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse(ippkt.payload()).unwrap();
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
-        assert!(udppkt.checksum() == 0xbc86);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
+        assert_eq!(udppkt.checksum(), 0xbc86);
     }
 }
 
@@ -55,21 +55,21 @@ fn batched_app(batch: &mut ArrayVec<Mbuf, 32>) {
         let buf = Pbuf::new(mbuf);
 
         let ethpkt = EtherPacket::parse(buf).unwrap();
-        assert!(ethpkt.ethertype() == EtherType::IPV4);
+        assert_eq!(ethpkt.ethertype(), EtherType::IPV4);
 
         let ippkt = Ipv4Packet::parse(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == IpProtocol::UDP);
+        assert_eq!(ippkt.protocol(), IpProtocol::UDP);
 
         let udppkt = UdpPacket::parse(ippkt.payload()).unwrap();
-        assert!(udppkt.source_port() == 60376);
-        assert!(udppkt.dest_port() == 161);
-        assert!(udppkt.packet_len() == 74);
+        assert_eq!(udppkt.source_port(), 60376);
+        assert_eq!(udppkt.dest_port(), 161);
+        assert_eq!(udppkt.packet_len(), 74);
 
         let payload = udppkt.payload();
 
         let mut b = [0; 66];
         (&mut b[..]).copy_from_slice(payload.chunk());
-        assert!(b[0..66] == FRAME_BYTES[42..108]);
+        assert_eq!(b[0..66], FRAME_BYTES[42..108]);
     }
 }
 

--- a/benches/dpdk/pbuf_parse.rs
+++ b/benches/dpdk/pbuf_parse.rs
@@ -1,10 +1,10 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/benches/dpdk/smol_build.rs
+++ b/benches/dpdk/smol_build.rs
@@ -1,6 +1,6 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
+use rpkt_dpdk::*;
 use smoltcp::wire;
 
 fn batched_build(batch: &mut ArrayVec<Mbuf, 32>, payload_len: usize) {

--- a/benches/dpdk/smol_fwd.rs
+++ b/benches/dpdk/smol_fwd.rs
@@ -1,6 +1,6 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
+use rpkt_dpdk::*;
 use smoltcp::wire;
 
 static FRAME_BYTES: [u8; 110] = [

--- a/benches/dpdk/smol_parse.rs
+++ b/benches/dpdk/smol_parse.rs
@@ -16,51 +16,51 @@ static FRAME_BYTES: [u8; 110] = [
 fn batched_l3(batch: &mut ArrayVec<Mbuf, 32>) {
     for mbuf in batch.iter_mut() {
         let ethpkt = wire::EthernetFrame::new_checked(mbuf.data()).unwrap();
-        assert!(ethpkt.ethertype() == wire::EthernetProtocol::Ipv4);
+        assert_eq!(ethpkt.ethertype(), wire::EthernetProtocol::Ipv4);
 
         let ippkt = wire::Ipv4Packet::new_checked(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == wire::IpProtocol::Udp);
-        assert!(ippkt.src_addr() == wire::Ipv4Address([192, 168, 29, 58]));
-        assert!(ippkt.dst_addr() == wire::Ipv4Address([192, 168, 29, 160]));
-        assert!(ippkt.checksum() == 0x0000);
-        assert!(ippkt.ident() == 0x5c65);
+        assert_eq!(ippkt.protocol(), wire::IpProtocol::Udp);
+        assert_eq!(ippkt.src_addr(), wire::Ipv4Address([192, 168, 29, 58]));
+        assert_eq!(ippkt.dst_addr(), wire::Ipv4Address([192, 168, 29, 160]));
+        assert_eq!(ippkt.checksum(), 0x0000);
+        assert_eq!(ippkt.ident(), 0x5c65);
     }
 }
 
 fn batched_l4(batch: &mut ArrayVec<Mbuf, 32>) {
     for mbuf in batch.iter_mut() {
         let ethpkt = wire::EthernetFrame::new_checked(mbuf.data()).unwrap();
-        assert!(ethpkt.ethertype() == wire::EthernetProtocol::Ipv4);
+        assert_eq!(ethpkt.ethertype(), wire::EthernetProtocol::Ipv4);
 
         let ippkt = wire::Ipv4Packet::new_checked(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == wire::IpProtocol::Udp);
+        assert_eq!(ippkt.protocol(), wire::IpProtocol::Udp);
 
         let udppkt = wire::UdpPacket::new_checked(ippkt.payload()).unwrap();
-        assert!(udppkt.src_port() == 60376);
-        assert!(udppkt.dst_port() == 161);
-        assert!(udppkt.len() == 74);
-        assert!(udppkt.checksum() == 0xbc86);
+        assert_eq!(udppkt.src_port(), 60376);
+        assert_eq!(udppkt.dst_port(), 161);
+        assert_eq!(udppkt.len(), 74);
+        assert_eq!(udppkt.checksum(), 0xbc86);
     }
 }
 
 fn batched_app(batch: &mut ArrayVec<Mbuf, 32>) {
     for mbuf in batch.iter_mut() {
         let ethpkt = wire::EthernetFrame::new_checked(mbuf.data()).unwrap();
-        assert!(ethpkt.ethertype() == wire::EthernetProtocol::Ipv4);
+        assert_eq!(ethpkt.ethertype(), wire::EthernetProtocol::Ipv4);
 
         let ippkt = wire::Ipv4Packet::new_checked(ethpkt.payload()).unwrap();
-        assert!(ippkt.protocol() == wire::IpProtocol::Udp);
+        assert_eq!(ippkt.protocol(), wire::IpProtocol::Udp);
 
         let udppkt = wire::UdpPacket::new_checked(ippkt.payload()).unwrap();
-        assert!(udppkt.src_port() == 60376);
-        assert!(udppkt.dst_port() == 161);
-        assert!(udppkt.len() == 74);
+        assert_eq!(udppkt.src_port(), 60376);
+        assert_eq!(udppkt.dst_port(), 161);
+        assert_eq!(udppkt.len(), 74);
 
         let payload = udppkt.payload();
 
         let mut b = [0; 66];
         (&mut b[..]).copy_from_slice(payload);
-        assert!(b[0..66] == FRAME_BYTES[42..108]);
+        assert_eq!(b[0..66], FRAME_BYTES[42..108]);
     }
 }
 

--- a/benches/dpdk/smol_parse.rs
+++ b/benches/dpdk/smol_parse.rs
@@ -1,6 +1,6 @@
 use arrayvec::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_dpdk::*;
+use rpkt_dpdk::*;
 use smoltcp::wire;
 
 static FRAME_BYTES: [u8; 110] = [

--- a/benches/packet/packet_build.rs
+++ b/benches/packet/packet_build.rs
@@ -1,9 +1,9 @@
 use bytes::Buf;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::CursorMut;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::CursorMut;
 
 fn packet_build(buf: &mut [u8], payload_len: usize) {
     let mut pkt = CursorMut::new(&mut buf[0..42 + payload_len]);

--- a/benches/packet/packet_parse.rs
+++ b/benches/packet/packet_parse.rs
@@ -1,9 +1,9 @@
 use bytes::{Buf, BufMut};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Cursor;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Cursor;
 
 static FRAME_BYTES: [u8; 110] = [
     0x00, 0x0b, 0x86, 0x64, 0x8b, 0xa0, 0x00, 0x50, 0x56, 0xae, 0x76, 0xf5, 0x08, 0x00, 0x45, 0x00,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,13 +5,13 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-criterion = "0.3"
-smoltcp = "0.8"
+criterion = "0.5.1"
+smoltcp = "0.8.2"
 arrayvec = "0.7.2"
 ctrlc = { version = "3.0", features = ["termination"]}
-run-time = {path = "../rpkt-time", package = "rpkt-time"}
-run-dpdk = {path = "../rpkt-dpdk", package = "rpkt-dpdk"}
-run-packet = {path = "../rpkt", package = "rpkt"}
+rpkt-time = {path = "../rpkt-time", package = "rpkt-time"}
+rpkt-dpdk = {path = "../rpkt-dpdk", package = "rpkt-dpdk"}
+rpkt = {path = "../rpkt", package = "rpkt"}
 
 
 #[[example]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,50 +14,50 @@ rpkt-dpdk = {path = "../rpkt-dpdk", package = "rpkt-dpdk"}
 rpkt = {path = "../rpkt", package = "rpkt"}
 
 
-#[[example]]
-#name = "port_test"
-#path = "dpdk/port_test.rs"
+[[example]]
+name = "port_test"
+path = "dpdk/port_test.rs"
 
 [[example]]
 name = "tx_test"
 path = "dpdk/tx_test.rs"
 
-#[[example]]
-#name = "tx_slow"
-#path = "dpdk/tx_slow.rs"
+[[example]]
+name = "tx_slow"
+path = "dpdk/tx_slow.rs"
 
-#[[example]]
-#name = "tx_multiseg_slow"
-#path = "dpdk/tx_multiseg_slow.rs"
+[[example]]
+name = "tx_multiseg_slow"
+path = "dpdk/tx_multiseg_slow.rs"
 
 [[example]]
 name = "rx_test"
 path = "dpdk/rx_test.rs"
 
-#[[example]]
-#name = "rx_print"
-#path = "dpdk/rx_print.rs"
+[[example]]
+name = "rx_print"
+path = "dpdk/rx_print.rs"
 
-#[[example]]
-#name = "rx_multiseg_print"
-#path = "dpdk/rx_multiseg_print.rs"
+[[example]]
+name = "rx_multiseg_print"
+path = "dpdk/rx_multiseg_print.rs"
 
-#[[example]]
-#name = "smoltcp_send_test"
-#path = "dpdk/smoltcp_send_test.rs"
+[[example]]
+name = "smoltcp_send_test"
+path = "dpdk/smoltcp_send_test.rs"
 
-#[[example]]
-#name = "mbuf_test"
-#path = "dpdk/mbuf_test.rs"
+[[example]]
+name = "mbuf_test"
+path = "dpdk/mbuf_test.rs"
 
-#[[example]]
-#name = "traffic_gen"
-#path = "dpdk/traffic_gen.rs"
+[[example]]
+name = "traffic_gen"
+path = "dpdk/traffic_gen.rs"
 
-#[[example]]
-#name = "traffic_fwd"
-#path = "dpdk/traffic_fwd.rs"
+[[example]]
+name = "traffic_fwd"
+path = "dpdk/traffic_fwd.rs"
 
-#[[example]]
-#name = "smol_traffic_fwd"
-#path = "dpdk/smol_traffic_fwd.rs"
+[[example]]
+name = "smol_traffic_fwd"
+path = "dpdk/smol_traffic_fwd.rs"

--- a/examples/dpdk/mbuf_test.rs
+++ b/examples/dpdk/mbuf_test.rs
@@ -2,7 +2,7 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
+use rpkt_dpdk::*;
 
 fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
     let nb_mbufs = 4096;
@@ -43,7 +43,7 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        run_dpdk::Lcore::current().unwrap().lcore_id
+        rpkt_dpdk::Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -64,7 +64,7 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
             }
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                run_dpdk::Lcore::current().unwrap().lcore_id
+                rpkt_dpdk::Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -113,7 +113,7 @@ fn cache_enabled_single(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        run_dpdk::Lcore::current().unwrap().lcore_id
+        rpkt_dpdk::Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -132,7 +132,7 @@ fn cache_enabled_single(base_idx: u32, nb_threads: u32) {
             }
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                run_dpdk::Lcore::current().unwrap().lcore_id
+                rpkt_dpdk::Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -177,7 +177,7 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from current mempool has been set with test data 99",
-        run_dpdk::Lcore::current().unwrap().lcore_id
+        rpkt_dpdk::Lcore::current().unwrap().lcore_id
     );
     drop(v);
 
@@ -200,7 +200,7 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
             }
             println!(
                 "lcore {}: all the mbufs from the local cache are set with test data 99",
-                run_dpdk::Lcore::current().unwrap().lcore_id
+                rpkt_dpdk::Lcore::current().unwrap().lcore_id
             );
         }));
     }

--- a/examples/dpdk/mbuf_test.rs
+++ b/examples/dpdk/mbuf_test.rs
@@ -19,7 +19,7 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
 
     let mp = service().mempool("wtf").unwrap();
     let mut batch = ArrayVec::<_, 128>::new();
-    assert!(nb_mbufs % 128 == 0);
+    assert_eq!(nb_mbufs % 128, 0);
     // On the current rte thread, try to alloc `nb_mbufs / 128` batches, and
     // fill in test data.
     for _ in 0..(nb_mbufs / 128) {
@@ -37,13 +37,13 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
         mp.fill_batch(&mut batch);
         for mbuf in batch.iter_mut() {
             unsafe { mbuf.extend(1) };
-            assert!(mbuf.data()[0] == 99);
+            assert_eq!(mbuf.data()[0], 99);
         }
         batch.drain(..);
     }
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        rpkt_dpdk::Lcore::current().unwrap().lcore_id
+        Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -58,13 +58,13 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
                 mp.fill_batch(&mut batch);
                 for mbuf in batch.iter_mut() {
                     unsafe { mbuf.extend(1) };
-                    assert!(mbuf.data()[0] != 99);
+                    assert_ne!(mbuf.data()[0], 99);
                 }
                 batch.drain(..);
             }
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                rpkt_dpdk::Lcore::current().unwrap().lcore_id
+                Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -109,11 +109,11 @@ fn cache_enabled_single(base_idx: u32, nb_threads: u32) {
         unsafe { mbuf.extend(1) };
 
         let data = mbuf.data();
-        assert!(data[0] == 99);
+        assert_eq!(data[0], 99);
     }
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        rpkt_dpdk::Lcore::current().unwrap().lcore_id
+        Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -128,11 +128,11 @@ fn cache_enabled_single(base_idx: u32, nb_threads: u32) {
                 unsafe { mbuf.extend(1) };
 
                 let data = mbuf.data();
-                assert!(data[0] != 99);
+                assert_ne!(data[0], 99);
             }
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                rpkt_dpdk::Lcore::current().unwrap().lcore_id
+                Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -177,7 +177,7 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from current mempool has been set with test data 99",
-        rpkt_dpdk::Lcore::current().unwrap().lcore_id
+        Lcore::current().unwrap().lcore_id
     );
     drop(v);
 
@@ -194,13 +194,13 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
                 mp.fill_batch(&mut batch);
                 for mbuf in batch.iter_mut() {
                     unsafe { mbuf.extend(1) };
-                    assert!(mbuf.data()[0] == 99);
+                    assert_eq!(mbuf.data()[0], 99);
                 }
                 Mempool::free_batch(&mut batch);
             }
             println!(
                 "lcore {}: all the mbufs from the local cache are set with test data 99",
-                rpkt_dpdk::Lcore::current().unwrap().lcore_id
+                Lcore::current().unwrap().lcore_id
             );
         }));
     }

--- a/examples/dpdk/port_test.rs
+++ b/examples/dpdk/port_test.rs
@@ -1,8 +1,8 @@
 // use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
-use run_packet::ether::MacAddr;
-use run_dpdk::*;
+use rpkt::ether::MacAddr;
+use rpkt_dpdk::*;
 // use ctrlc;
 
 fn main() {

--- a/examples/dpdk/port_test.rs
+++ b/examples/dpdk/port_test.rs
@@ -12,8 +12,8 @@ fn main() {
         println!("lcore {} on socket {}", lcore.lcore_id, lcore.socket_id);
     }
 
-    let port_infos = service().port_infos().unwrap();
-    for port_info in port_infos {
+    for port_num in 0..service().port_num().unwrap() {
+        let port_info = service().port_info(port_num).unwrap();
         println!(
             "port {} with driver {} on socket {} with mac addr {}, started {}",
             port_info.port_id,
@@ -64,6 +64,7 @@ fn main() {
     }
 
     let mut mpconf = MempoolConf::default();
+    // TODO: Make it configurable
     mpconf.socket_id = 1;
     service().mempool_create("wtf", &mpconf).unwrap();
     println!("mempool wtf created");
@@ -72,8 +73,15 @@ fn main() {
     let mut rxq_confs = Vec::new();
     let mut txq_confs = Vec::new();
     for _ in 0..4 {
-        rxq_confs.push(RxQueueConf::new(128, 0, "wtf"));
-        txq_confs.push(TxQueueConf::new(128, 0));
+        let mut rx_queue = RxQueueConf::new();
+        rx_queue.set_nb_rx_desc(128);
+        rx_queue.set_socket_id(0);
+        rx_queue.set_mp_name("wtf");
+        rxq_confs.push(rx_queue);
+        let mut tx_queue = TxQueueConf::new();
+        tx_queue.set_nb_tx_desc(128);
+        tx_queue.set_socket_id(0);
+        txq_confs.push(tx_queue);
     }
     println!("create confs");
 

--- a/examples/dpdk/rx_multiseg_print.rs
+++ b/examples/dpdk/rx_multiseg_print.rs
@@ -2,12 +2,12 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
 
 // test pmd test command:
 // sudo ./dpdk-testpmd -l 0-16 -n 4 -- -i  --portlist=0 --forward-mode=rxonly --txq=16 --rxq=16 --nb-cores=16

--- a/examples/dpdk/rx_multiseg_print.rs
+++ b/examples/dpdk/rx_multiseg_print.rs
@@ -24,14 +24,13 @@ fn init_port(
     rxq_conf: &mut RxQueueConf,
     txq_conf: &mut TxQueueConf,
 ) {
-    let port_infos = service().port_infos().unwrap();
-    let port_info = &port_infos[port_id as usize];
+    let port_info = service().port_info(port_id).unwrap();
     let socket_id = port_info.socket_id;
 
     mpconf.socket_id = socket_id;
     service().mempool_create(mp_name, mpconf).unwrap();
 
-    let mut pconf = PortConf::from_port_info(port_info).unwrap();
+    let mut pconf = PortConf::from_port_info(&port_info).unwrap();
     pconf.mtu = 9000;
     pconf.rx_offloads.enable_scatter();
     pconf.tx_offloads.enable_multi_segs();
@@ -76,13 +75,13 @@ fn main() {
     );
 
     let start_core = 1;
-    let socket_id = service().port_infos().unwrap()[port_id as usize].socket_id;
+    let socket_id = service().port_info(port_id).unwrap().socket_id;
     service()
         .lcores()
         .iter()
         .find(|lcore| lcore.lcore_id >= start_core && lcore.lcore_id < start_core + nb_qs)
         .map(|lcore| {
-            assert!(lcore.socket_id == socket_id, "core with invalid socket id");
+            assert_eq!(lcore.socket_id, socket_id, "core with invalid socket id");
         });
 
     let run = Arc::new(AtomicBool::new(true));
@@ -98,7 +97,7 @@ fn main() {
 
         let jh = std::thread::spawn(move || {
             service().lcore_bind(i + 1).unwrap();
-            let mut rxq = service().rx_queue(port_id as u16, i as u16).unwrap();
+            let mut rxq = service().rx_queue(port_id, i as u16).unwrap();
             let mut batch = ArrayVec::<_, 32>::new();
 
             while run.load(Ordering::Acquire) {

--- a/examples/dpdk/rx_print.rs
+++ b/examples/dpdk/rx_print.rs
@@ -2,13 +2,13 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::Cursor;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::Cursor;
 
 // test pmd test command:
 // sudo ./dpdk-testpmd -l 0-16 -n 4 -- -i  --portlist=0 --forward-mode=rxonly --txq=16 --rxq=16 --nb-cores=16

--- a/examples/dpdk/rx_test.rs
+++ b/examples/dpdk/rx_test.rs
@@ -2,8 +2,8 @@ use std::sync::{atomic::AtomicBool, atomic::AtomicUsize, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
-use run_time::*;
+use rpkt_dpdk::*;
+use rpkt_time::*;
 
 // test pmd test command:
 // sudo ./dpdk-testpmd -l 0-16 -n 4 -- -i  --portlist=0 --forward-mode=rxonly --txq=16 --rxq=16 --nb-cores=16

--- a/examples/dpdk/rx_test.rs
+++ b/examples/dpdk/rx_test.rs
@@ -67,6 +67,8 @@ fn main() {
         &mut txq_conf,
     );
 
+    // Change this value to be half of available cores
+    // TODO: Make it configurable
     let start_core = 33;
     let socket_id = service().port_info(port_id).unwrap().socket_id;
     service()
@@ -74,7 +76,7 @@ fn main() {
         .iter()
         .find(|lcore| lcore.lcore_id >= start_core && lcore.lcore_id < start_core + nb_qs)
         .map(|lcore| {
-            assert!(lcore.socket_id == socket_id, "core with invalid socket id");
+            assert_eq!(lcore.socket_id, socket_id, "core with invalid socket id");
         });
 
     let run = Arc::new(AtomicBool::new(true));
@@ -96,7 +98,7 @@ fn main() {
 
         let jh = std::thread::spawn(move || {
             service().lcore_bind(i + start_core).unwrap();
-            let mut rxq = service().rx_queue(port_id as u16, i as u16).unwrap();
+            let mut rxq = service().rx_queue(port_id, i as u16).unwrap();
             let mut batch = ArrayVec::<_, 64>::new();
 
             let mut total_pkts = 0;
@@ -154,7 +156,7 @@ fn main() {
                     bps_stats[qid].load(Ordering::SeqCst) as f64 * 8.0 / 1000000000.0,
                 );
             }
-            println!("");
+            println!();
         }
     }
 

--- a/examples/dpdk/smol_traffic_fwd.rs
+++ b/examples/dpdk/smol_traffic_fwd.rs
@@ -2,7 +2,7 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
+use rpkt_dpdk::*;
 use smoltcp::wire;
 
 const BATCHSIZE: usize = 32;

--- a/examples/dpdk/smoltcp_send_test.rs
+++ b/examples/dpdk/smoltcp_send_test.rs
@@ -2,7 +2,7 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
+use rpkt_dpdk::*;
 use smoltcp::wire;
 
 fn main() {

--- a/examples/dpdk/smoltcp_send_test.rs
+++ b/examples/dpdk/smoltcp_send_test.rs
@@ -18,8 +18,15 @@ fn main() {
     let mut rxq_confs = Vec::new();
     let mut txq_confs = Vec::new();
     for _ in 0..nb_qs {
-        rxq_confs.push(RxQueueConf::new(1024, 0, "wtf"));
-        txq_confs.push(TxQueueConf::new(1024, 0));
+        let mut rx_queue = RxQueueConf::new();
+        rx_queue.set_nb_rx_desc(1024);
+        rx_queue.set_socket_id(0);
+        rx_queue.set_mp_name("wtf");
+        rxq_confs.push(rx_queue);
+        let mut tx_queue = TxQueueConf::new();
+        tx_queue.set_nb_tx_desc(1024);
+        tx_queue.set_socket_id(0);
+        txq_confs.push(tx_queue);
     }
 
     service()
@@ -87,10 +94,10 @@ fn main() {
         jhs.push(jh);
     }
 
-    let mut old_stats = service().port_stats(0).unwrap();
+    let mut old_stats = service().stats_query(0).unwrap().query();
     while run_curr.load(Ordering::Acquire) {
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let curr_stats = service().port_stats(0).unwrap();
+        let curr_stats = service().stats_query(0).unwrap().query();
         println!(
             "pkts per sec: {}, bytes per sec: {}, errors per sec: {}",
             curr_stats.opackets() - old_stats.opackets(),

--- a/examples/dpdk/traffic_fwd.rs
+++ b/examples/dpdk/traffic_fwd.rs
@@ -26,8 +26,7 @@ fn init_port(
     rxq_conf: &mut RxQueueConf,
     txq_conf: &mut TxQueueConf,
 ) {
-    let port_infos = service().port_infos().unwrap();
-    let port_info = &port_infos[port_id as usize];
+    let port_info = &service().port_info(port_id).unwrap();
     let socket_id = port_info.socket_id;
 
     mpconf.socket_id = socket_id;
@@ -91,21 +90,15 @@ fn main() {
     );
 
     let start_core = 1;
-    let iport_socket_id = service().port_infos().unwrap()[iport_id as usize].socket_id;
-    let oport_socket_id = service().port_infos().unwrap()[oport_id as usize].socket_id;
+    let iport_socket_id = service().port_info(iport_id).unwrap().socket_id;
+    let oport_socket_id = service().port_info(oport_id).unwrap().socket_id;
     service()
         .lcores()
         .iter()
         .find(|lcore| lcore.lcore_id >= start_core && lcore.lcore_id < start_core + nb_qs)
         .map(|lcore| {
-            assert!(
-                lcore.socket_id == iport_socket_id,
-                "core with invalid socket id"
-            );
-            assert!(
-                lcore.socket_id == oport_socket_id,
-                "core with invalid socket id"
-            );
+            assert_eq!(lcore.socket_id, iport_socket_id, "core with invalid socket id");
+            assert_eq!(lcore.socket_id, oport_socket_id, "core with invalid socket id");
         });
 
     let run = Arc::new(AtomicBool::new(true));
@@ -172,10 +165,10 @@ fn main() {
         jhs.push(jh);
     }
 
-    let mut old_stats = service().port_stats(oport_id).unwrap();
+    let mut old_stats = service().stats_query(oport_id).unwrap().query();
     while run.load(Ordering::Acquire) {
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let curr_stats = service().port_stats(oport_id).unwrap();
+        let curr_stats = service().stats_query(oport_id).unwrap().query();
         println!(
             "forwarded pkts: {} pps, {} Gbps, {} errors/s",
             curr_stats.opackets() - old_stats.opackets(),

--- a/examples/dpdk/traffic_fwd.rs
+++ b/examples/dpdk/traffic_fwd.rs
@@ -2,11 +2,11 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::CursorMut;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::CursorMut;
 
 const BATCHSIZE: usize = 32;
 

--- a/examples/dpdk/traffic_gen.rs
+++ b/examples/dpdk/traffic_gen.rs
@@ -2,12 +2,12 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::CursorMut;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::CursorMut;
 
 const BATCHSIZE: usize = 64;
 

--- a/examples/dpdk/traffic_gen.rs
+++ b/examples/dpdk/traffic_gen.rs
@@ -20,8 +20,7 @@ fn init_port(
     rxq_conf: &mut RxQueueConf,
     txq_conf: &mut TxQueueConf,
 ) {
-    let port_infos = service().port_infos().unwrap();
-    let port_info = &port_infos[port_id as usize];
+    let port_info = &service().port_info(port_id).unwrap();
     let socket_id = port_info.socket_id;
 
     service()
@@ -177,13 +176,13 @@ fn main() {
         jhs.push(jh);
     }
 
-    let mut p0_old_stats = service().port_stats(p0_id).unwrap();
-    let mut p1_old_stats = service().port_stats(p1_id).unwrap();
+    let mut p0_old_stats = service().stats_query(p0_id).unwrap().query();
+    let mut p1_old_stats = service().stats_query(p1_id).unwrap().query();
     while run.load(Ordering::Acquire) {
         std::thread::sleep(std::time::Duration::from_secs(1));
 
-        let p0_curr_stats = service().port_stats(p0_id).unwrap();
-        let p1_curr_stats = service().port_stats(p1_id).unwrap();
+        let p0_curr_stats = service().stats_query(p0_id).unwrap().query();
+        let p1_curr_stats = service().stats_query(p1_id).unwrap().query();
 
         println!(
             "tx: {} pps, {} Gbps; rx: {} pps, {} Gps; rx_missed: {} pps",

--- a/examples/dpdk/tx_multiseg_slow.rs
+++ b/examples/dpdk/tx_multiseg_slow.rs
@@ -2,13 +2,13 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::offload::*;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
+use rpkt_dpdk::offload::*;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
 
 static FRAME_BYTES: [u8; 200] = [
     0x00, 0x26, 0x62, 0x2f, 0x47, 0x87, 0x00, 0x1d, 0x60, 0xb3, 0x01, 0x84, 0x08, 0x00, 0x45, 0x00,

--- a/examples/dpdk/tx_slow.rs
+++ b/examples/dpdk/tx_slow.rs
@@ -2,14 +2,14 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::offload::*;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::CursorMut;
+use rpkt_dpdk::offload::*;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::CursorMut;
 
 static FRAME_BYTES: [u8; 200] = [
     0x00, 0x26, 0x62, 0x2f, 0x47, 0x87, 0x00, 0x1d, 0x60, 0xb3, 0x01, 0x84, 0x08, 0x00, 0x45, 0x00,

--- a/examples/dpdk/tx_slow.rs
+++ b/examples/dpdk/tx_slow.rs
@@ -124,7 +124,7 @@ fn build_tcp_manual<'a>(mbuf: &mut Mbuf, payload_len: usize) {
     tcppkt.set_fin(false);
     tcppkt.set_window_size(46);
     tcppkt.set_urgent_ptr(0);
-    tcppkt.set_option_bytes(
+    tcppkt.option_bytes_mut().copy_from_slice(
         &FRAME_BYTES[ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN
             ..(ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN + 12)],
     );
@@ -173,7 +173,7 @@ fn build_tcp_offload<'a>(mbuf: &mut Mbuf, payload_len: usize) {
     tcppkt.set_fin(false);
     tcppkt.set_window_size(46);
     tcppkt.set_urgent_ptr(0);
-    tcppkt.set_option_bytes(
+    tcppkt.option_bytes_mut().copy_from_slice(
         &FRAME_BYTES[ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN
             ..(ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN + 12)],
     );
@@ -210,8 +210,7 @@ fn init_port(
     rxq_conf: &mut RxQueueConf,
     txq_conf: &mut TxQueueConf,
 ) {
-    let port_infos = service().port_infos().unwrap();
-    let port_info = &port_infos[port_id as usize];
+    let port_info = &service().port_info(port_id).unwrap();
     let socket_id = port_info.socket_id;
 
     mpconf.socket_id = socket_id;
@@ -260,7 +259,7 @@ fn main() {
     );
 
     let start_core = 1;
-    let socket_id = service().port_infos().unwrap()[port_id as usize].socket_id;
+    let socket_id = service().port_info(port_id).unwrap().socket_id;
     service()
         .lcores()
         .iter()
@@ -303,10 +302,10 @@ fn main() {
         jhs.push(jh);
     }
 
-    let mut old_stats = service().port_stats(port_id).unwrap();
+    let mut old_stats = service().stats_query(port_id).unwrap().query();
     while run_curr.load(Ordering::Acquire) {
         std::thread::sleep(std::time::Duration::from_secs(1));
-        let curr_stats = service().port_stats(port_id).unwrap();
+        let curr_stats = service().stats_query(port_id).unwrap().query();
         println!(
             "pkts per sec: {}, bytes per sec: {}, errors per sec: {}",
             curr_stats.opackets() - old_stats.opackets(),

--- a/examples/dpdk/tx_test.rs
+++ b/examples/dpdk/tx_test.rs
@@ -90,7 +90,7 @@ fn main() {
         .iter()
         .find(|lcore| lcore.lcore_id >= start_core && lcore.lcore_id < start_core + nb_qs)
         .map(|lcore| {
-            assert!(lcore.socket_id == socket_id, "core with invalid socket id");
+            assert_eq!(lcore.socket_id, socket_id, "core with invalid socket id");
         });
 
     let run = Arc::new(AtomicBool::new(true));

--- a/examples/dpdk/tx_test.rs
+++ b/examples/dpdk/tx_test.rs
@@ -2,13 +2,13 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::offload::MbufTxOffload;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::CursorMut;
+use rpkt_dpdk::offload::MbufTxOffload;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::CursorMut;
 
 // use packet::ether::;
 

--- a/rpkt-dpdk-sys/Cargo.toml
+++ b/rpkt-dpdk-sys/Cargo.toml
@@ -13,5 +13,6 @@ rust-version.workspace = true
 license.workspace = true
 
 [build-dependencies]
-bindgen = "0.59" 
+version-compare = "0.1.1"
+bindgen = "0.69.4"
 cc = "1"

--- a/rpkt-dpdk-sys/README.md
+++ b/rpkt-dpdk-sys/README.md
@@ -1,3 +1,5 @@
 # DPDK Version
-The current DPDK version is 21.11.
+Minimal supported DPDK version is 23.11.
+
+It is not guaranteed to work on anything above 24.03 though.
 

--- a/rpkt-dpdk-sys/README.md
+++ b/rpkt-dpdk-sys/README.md
@@ -1,5 +1,7 @@
 # DPDK Version
-Minimal supported DPDK version is 23.11.
+Minimal supported DPDK version is 21.11.
+
+Tested on 23.11
 
 It is not guaranteed to work on anything above 24.03 though.
 

--- a/rpkt-dpdk-sys/build.rs
+++ b/rpkt-dpdk-sys/build.rs
@@ -3,8 +3,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
+use bindgen::Formatter;
 
-const DPDK_VERSION: &str = "21.11";
+use version_compare::{Version};
+
+const DPDK_PREFERRED_VERSION: &str = "23.11";
 const DPDK_GIT_REPO: &str = "https://dpdk.org/git/dpdk";
 
 // On Ubuntu server, we need the following packages:
@@ -83,7 +86,7 @@ fn build_dpdk_ffi() {
         bgbuilder = bgbuilder.clang_arg(cflag);
     }
     bgbuilder
-        .rustfmt_bindings(true)
+        .formatter(Formatter::Rustfmt)
         .generate()
         .expect("Unable to generate rust bingdings from csrc/header.h.")
         .write_to_file(outdir.join("dpdk.rs"))
@@ -128,6 +131,11 @@ fn build_dpdk_ffi() {
 }
 
 fn main() {
+    // At this moment, rpkt doesn't provide bindings to anything that was changed since 21.11
+    // That value should be updated, once those methods/structs would be exposed
+    let dpdk_min_version: Version = Version::from("21.11").unwrap();
+    // It is not guaranteed that there will be no significant ABI/API changes later
+    let dpdk_max_version: Version = Version::from("24.03.9999").unwrap();
     // Check DPDK version.
     let output = Command::new("pkg-config")
         .args(&["--modversion", "libdpdk"])
@@ -136,10 +144,21 @@ fn main() {
     if output.status.success() {
         let s = String::from_utf8(output.stdout).unwrap();
         let version_str = s.trim();
-        if !version_str.starts_with(DPDK_VERSION) {
+        let version = Version::from(version_str).unwrap();
+        if version < dpdk_min_version {
             panic!(
-                "pkg-config finds DPDK library with version {}.\nPlease install a supported version.\n",
-                version_str
+                "pkg-config finds DPDK library with version {} which is too old.\nPlease install version between {} and {}.\n",
+                version_str,
+                dpdk_min_version,
+                dpdk_max_version
+            );
+        }
+        if version > dpdk_max_version {
+            panic!(
+                "pkg-config finds DPDK library with version {} which is too new.\nPlease install version between {} and {}.\n",
+                version_str,
+                dpdk_min_version,
+                dpdk_max_version
             );
         }
 
@@ -154,7 +173,7 @@ fn main() {
     // Download DPDK source from the official git repo.
     if !Path::new("deps/dpdk").is_dir() {
         let mut tag = "v".to_string();
-        tag.push_str(DPDK_VERSION);
+        tag.push_str(DPDK_PREFERRED_VERSION);
         let res = Command::new("git")
             .args(&["clone", "-b", &tag, DPDK_GIT_REPO, "deps/dpdk"])
             .status()

--- a/rpkt-dpdk-sys/build.rs
+++ b/rpkt-dpdk-sys/build.rs
@@ -27,7 +27,7 @@ fn build_dpdk_ffi() {
         .args(&["--cflags", "libdpdk"])
         .output()
         .unwrap();
-    assert!(output.status.success() == true);
+    assert_eq!(output.status.success(), true);
     let cflags = String::from_utf8(output.stdout).unwrap();
 
     // Compile the csrc/impl.c file into a static library.
@@ -98,7 +98,7 @@ fn build_dpdk_ffi() {
         .args(&["--libs", "--static", "libdpdk"])
         .output()
         .unwrap();
-    assert!(output.status.success() == true);
+    assert_eq!(output.status.success(), true);
     let ldflags = String::from_utf8(output.stdout).unwrap();
     for ldflag in ldflags.trim().split(' ') {
         if ldflag.starts_with("-L") {

--- a/rpkt-dpdk/Cargo.toml
+++ b/rpkt-dpdk/Cargo.toml
@@ -14,21 +14,21 @@ license.workspace = true
 
 [dependencies]
 libc = "0.2"
-arrayvec = "0.7.2"
+arrayvec = "0.7.4"
 once_cell = "1.9.0"
-run-dpdk-sys = { path = "../rpkt-dpdk-sys", package = "rpkt-dpdk-sys", version = "0.1.0"}
-run-packet = {path = "../rpkt", package = "rpkt", optional = true, version = "0.1.0"}
+rpkt-dpdk-sys = { path = "../rpkt-dpdk-sys", package = "rpkt-dpdk-sys", version = "0.1.0"}
+rpkt = {path = "../rpkt", package = "rpkt", optional = true, version = "0.1.0"}
 
 [features]
 # `multiseg` feature enables non-contiguous `Mbuf` and `Pbuf`
 # default = ["multiseg"]
-multiseg = ["dep:run-packet"]
+multiseg = ["dep:rpkt"]
 
 [dev-dependencies]
-run-time = {path = "../rpkt-time", package = "rpkt-time"}
-run-packet = {path = "../rpkt", package = "rpkt"}
+rpkt-time = {path = "../rpkt-time", package = "rpkt-time"}
+rpkt = {path = "../rpkt", package = "rpkt"}
 ctrlc = { version = "3.0", features = ["termination"]}
-smoltcp = "0.8"
+smoltcp = "0.8.2"
 
 [[example]]
 name = "jumboframe_tx"

--- a/rpkt-dpdk/examples/checksum_offload_rx.rs
+++ b/rpkt-dpdk/examples/checksum_offload_rx.rs
@@ -37,10 +37,10 @@ fn entry_func() {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/checksum_offload_rx.rs
+++ b/rpkt-dpdk/examples/checksum_offload_rx.rs
@@ -4,12 +4,12 @@ use arrayvec::ArrayVec;
 use ctrlc;
 
 use rpkt_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::Cursor;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::Cursor;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 0;

--- a/rpkt-dpdk/examples/checksum_offload_tx.rs
+++ b/rpkt-dpdk/examples/checksum_offload_tx.rs
@@ -316,10 +316,10 @@ fn entry_func(val: u64) {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/checksum_offload_tx.rs
+++ b/rpkt-dpdk/examples/checksum_offload_tx.rs
@@ -6,12 +6,12 @@ use ctrlc;
 
 use rpkt_dpdk::offload::MbufTxOffload;
 use rpkt_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::CursorMut;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::CursorMut;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 0;
@@ -157,7 +157,7 @@ fn build_tcp_manual(mbuf: &mut Mbuf) {
     tcppkt.set_fin(false);
     tcppkt.set_window_size(46);
     tcppkt.set_urgent_ptr(0);
-    tcppkt.set_option_bytes(
+    tcppkt.option_bytes_mut().copy_from_slice(
         &FRAME_BYTES[ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN
             ..(ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN + 12)],
     );
@@ -207,7 +207,7 @@ fn build_tcp_offload(mbuf: &mut Mbuf) {
     tcppkt.set_fin(false);
     tcppkt.set_window_size(46);
     tcppkt.set_urgent_ptr(0);
-    tcppkt.set_option_bytes(
+    tcppkt.option_bytes_mut().copy_from_slice(
         &FRAME_BYTES[ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN
             ..(ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN + 12)],
     );

--- a/rpkt-dpdk/examples/jumboframe_rx.rs
+++ b/rpkt-dpdk/examples/jumboframe_rx.rs
@@ -3,12 +3,12 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 use arrayvec::ArrayVec;
 use ctrlc;
 
-use run_dpdk::error::{Error, Result};
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
+use rpkt_dpdk::error::{Error, Result};
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 0;

--- a/rpkt-dpdk/examples/jumboframe_rx.rs
+++ b/rpkt-dpdk/examples/jumboframe_rx.rs
@@ -36,10 +36,10 @@ fn entry_func() {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/jumboframe_tx.rs
+++ b/rpkt-dpdk/examples/jumboframe_tx.rs
@@ -4,14 +4,14 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 use arrayvec::ArrayVec;
 use ctrlc;
 
-use run_dpdk::error::{Error, Result};
-use run_dpdk::offload::MbufTxOffload;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::tcp::*;
-use run_packet::udp::*;
-use run_packet::Buf;
+use rpkt_dpdk::error::{Error, Result};
+use rpkt_dpdk::offload::MbufTxOffload;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::tcp::*;
+use rpkt::udp::*;
+use rpkt::Buf;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 0;

--- a/rpkt-dpdk/examples/jumboframe_tx.rs
+++ b/rpkt-dpdk/examples/jumboframe_tx.rs
@@ -246,10 +246,10 @@ fn entry_func(val: u64) {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/jumboframe_tx.rs
+++ b/rpkt-dpdk/examples/jumboframe_tx.rs
@@ -158,7 +158,7 @@ fn build_tcp_manual(mp: &Mempool) -> Mbuf {
     tcppkt.set_fin(false);
     tcppkt.set_window_size(46);
     tcppkt.set_urgent_ptr(0);
-    tcppkt.set_option_bytes(
+    tcppkt.option_bytes_mut().copy_from_slice(
         &FRAME_BYTES[ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN
             ..(ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN + 12)],
     );
@@ -209,7 +209,7 @@ fn build_tcp_offload(mp: &Mempool) -> Mbuf {
     tcppkt.set_fin(false);
     tcppkt.set_window_size(46);
     tcppkt.set_urgent_ptr(0);
-    tcppkt.set_option_bytes(
+    tcppkt.option_bytes_mut().copy_from_slice(
         &FRAME_BYTES[ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN
             ..(ETHER_HEADER_LEN + IPV4_HEADER_LEN + TCP_HEADER_LEN + 12)],
     );

--- a/rpkt-dpdk/examples/loopback_rx.rs
+++ b/rpkt-dpdk/examples/loopback_rx.rs
@@ -68,10 +68,10 @@ fn entry_func() {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/loopback_rx.rs
+++ b/rpkt-dpdk/examples/loopback_rx.rs
@@ -4,12 +4,12 @@ use arrayvec::ArrayVec;
 use ctrlc;
 use once_cell::sync::OnceCell;
 
-use run_dpdk::offload::MbufTxOffload;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::UdpPacket;
-use run_packet::CursorMut;
+use rpkt_dpdk::offload::MbufTxOffload;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::UdpPacket;
+use rpkt::CursorMut;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 1;

--- a/rpkt-dpdk/examples/loopback_tx.rs
+++ b/rpkt-dpdk/examples/loopback_tx.rs
@@ -101,10 +101,10 @@ fn entry_func() {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/loopback_tx.rs
+++ b/rpkt-dpdk/examples/loopback_tx.rs
@@ -4,13 +4,13 @@ use arrayvec::ArrayVec;
 use ctrlc;
 use once_cell::sync::OnceCell;
 
-use run_dpdk::offload::MbufTxOffload;
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::udp::*;
-use run_packet::Buf;
-use run_packet::CursorMut;
+use rpkt_dpdk::offload::MbufTxOffload;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::udp::*;
+use rpkt::Buf;
+use rpkt::CursorMut;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 1;

--- a/rpkt-dpdk/examples/mbuf_test.rs
+++ b/rpkt-dpdk/examples/mbuf_test.rs
@@ -2,7 +2,7 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 
 use arrayvec::ArrayVec;
 use ctrlc;
-use run_dpdk::*;
+use rpkt_dpdk::*;
 
 const BATCH_SIZE: usize = 128;
 
@@ -50,7 +50,7 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        run_dpdk::Lcore::current().unwrap().lcore_id
+        rpkt_dpdk::Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -73,7 +73,7 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
 
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                run_dpdk::Lcore::current().unwrap().lcore_id
+                rpkt_dpdk::Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -125,7 +125,7 @@ fn cache_enabled_single_alloc(base_idx: u32, nb_threads: u32) {
 
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        run_dpdk::Lcore::current().unwrap().lcore_id
+        rpkt_dpdk::Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -146,7 +146,7 @@ fn cache_enabled_single_alloc(base_idx: u32, nb_threads: u32) {
 
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                run_dpdk::Lcore::current().unwrap().lcore_id
+                rpkt_dpdk::Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -192,7 +192,7 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from current mempool has been set with test data 99",
-        run_dpdk::Lcore::current().unwrap().lcore_id
+        rpkt_dpdk::Lcore::current().unwrap().lcore_id
     );
     drop(v);
 
@@ -216,7 +216,7 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
 
             println!(
                 "lcore {}: all the mbufs from the local cache are set with test data 99",
-                run_dpdk::Lcore::current().unwrap().lcore_id
+                rpkt_dpdk::Lcore::current().unwrap().lcore_id
             );
         }));
     }

--- a/rpkt-dpdk/examples/mbuf_test.rs
+++ b/rpkt-dpdk/examples/mbuf_test.rs
@@ -23,8 +23,8 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
     let mp = service().mempool("wtf").unwrap();
 
     let mut batch = ArrayVec::<_, BATCH_SIZE>::new();
-    assert!(nb_mbufs % BATCH_SIZE as u32 == 0);
-    assert!(per_core_caches % BATCH_SIZE as u32 == 0);
+    assert_eq!(nb_mbufs % BATCH_SIZE as u32, 0);
+    assert_eq!(per_core_caches % BATCH_SIZE as u32, 0);
 
     // On the current rte thread, try to alloc `nb_mbufs / BATCH_SIZE` batches,
     // and fill in test data.
@@ -44,13 +44,13 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
         mp.fill_batch(&mut batch);
         for mbuf in batch.iter_mut() {
             unsafe { mbuf.extend(1) };
-            assert!(mbuf.data()[0] == 99);
+            assert_eq!(mbuf.data()[0], 99);
         }
         batch.drain(..);
     }
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        rpkt_dpdk::Lcore::current().unwrap().lcore_id
+        Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -66,14 +66,14 @@ fn cache_enabled_batch(base_idx: u32, nb_threads: u32) {
                 mp.fill_batch(&mut batch);
                 for mbuf in batch.iter_mut() {
                     unsafe { mbuf.extend(1) };
-                    assert!(mbuf.data()[0] != 99);
+                    assert_ne!(mbuf.data()[0], 99);
                 }
                 batch.drain(..);
             }
 
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                rpkt_dpdk::Lcore::current().unwrap().lcore_id
+                Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -120,12 +120,12 @@ fn cache_enabled_single_alloc(base_idx: u32, nb_threads: u32) {
         unsafe { mbuf.extend(1) };
 
         let data = mbuf.data();
-        assert!(data[0] == 99);
+        assert_eq!(data[0], 99);
     }
 
     println!(
         "lcore {}: all the mbufs from the local cache has been set with test data 99",
-        rpkt_dpdk::Lcore::current().unwrap().lcore_id
+        Lcore::current().unwrap().lcore_id
     );
 
     let mut jhs = Vec::new();
@@ -141,12 +141,12 @@ fn cache_enabled_single_alloc(base_idx: u32, nb_threads: u32) {
                 unsafe { mbuf.extend(1) };
 
                 let data = mbuf.data();
-                assert!(data[0] != 99);
+                assert_ne!(data[0], 99);
             }
 
             println!(
                 "lcore {}: all the mbufs from the local cache are not set with test data 99",
-                rpkt_dpdk::Lcore::current().unwrap().lcore_id
+                Lcore::current().unwrap().lcore_id
             );
         }));
     }
@@ -192,7 +192,7 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
     }
     println!(
         "lcore {}: all the mbufs from current mempool has been set with test data 99",
-        rpkt_dpdk::Lcore::current().unwrap().lcore_id
+        Lcore::current().unwrap().lcore_id
     );
     drop(v);
 
@@ -209,14 +209,14 @@ fn set_all_mbufs_in_a_pool(base_idx: u32, nb_threads: u32) {
                 mp.fill_batch(&mut batch);
                 for mbuf in batch.iter_mut() {
                     unsafe { mbuf.extend(1) };
-                    assert!(mbuf.data()[0] == 99);
+                    assert_eq!(mbuf.data()[0], 99);
                 }
                 Mempool::free_batch(&mut batch);
             }
 
             println!(
                 "lcore {}: all the mbufs from the local cache are set with test data 99",
-                rpkt_dpdk::Lcore::current().unwrap().lcore_id
+                Lcore::current().unwrap().lcore_id
             );
         }));
     }

--- a/rpkt-dpdk/examples/rss_rx.rs
+++ b/rpkt-dpdk/examples/rss_rx.rs
@@ -4,11 +4,11 @@ use std::sync::{atomic::AtomicBool, atomic::AtomicUsize, atomic::Ordering, Arc};
 use arrayvec::ArrayVec;
 use ctrlc;
 
-use run_dpdk::*;
-use run_packet::ether::*;
-use run_packet::ipv4::*;
-use run_packet::Cursor;
-use run_time::*;
+use rpkt_dpdk::*;
+use rpkt::ether::*;
+use rpkt::ipv4::*;
+use rpkt::Cursor;
+use rpkt_time::*;
 
 // The socket to work on
 const WORKING_SOCKET: u32 = 1;

--- a/rpkt-dpdk/examples/rss_rx.rs
+++ b/rpkt-dpdk/examples/rss_rx.rs
@@ -35,10 +35,10 @@ fn entry_func() {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();

--- a/rpkt-dpdk/examples/traffic_fwd.rs
+++ b/rpkt-dpdk/examples/traffic_fwd.rs
@@ -76,10 +76,10 @@ fn entry_func() {
         .iter()
         .filter(|lcore| {
             lcore.lcore_id >= START_CORE as u32
-                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM as u32
+                && lcore.lcore_id < START_CORE as u32 + THREAD_NUM
         })
         .all(|lcore| lcore.socket_id == WORKING_SOCKET);
-    assert!(res == true);
+    assert_eq!(res, true);
 
     let run = Arc::new(AtomicBool::new(true));
     let run_clone = run.clone();
@@ -134,7 +134,7 @@ fn entry_func() {
                                         ethpkt.set_src_addr(wire::EthernetAddress(SMAC));
 
                                         mbuf.set_tx_offload(tx_of_flag);
-                                        mbuf.set_l2_len(14 as u64);
+                                        mbuf.set_l2_len(14u64);
                                         mbuf.set_l3_len(ip_hdr_len as u64);
                                     }
                                 }

--- a/rpkt-dpdk/examples/traffic_fwd.rs
+++ b/rpkt-dpdk/examples/traffic_fwd.rs
@@ -6,8 +6,8 @@ use ctrlc;
 use smoltcp::wire;
 
 use once_cell::sync::OnceCell;
-use run_dpdk::offload::MbufTxOffload;
-use run_dpdk::*;
+use rpkt_dpdk::offload::MbufTxOffload;
+use rpkt_dpdk::*;
 
 // the following result is acuiqred without setting ip checksum value
 // nbcore      1         2        3        4          14       18

--- a/rpkt-dpdk/src/lcore.rs
+++ b/rpkt-dpdk/src/lcore.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 
-use run_dpdk_sys as ffi;
+use rpkt_dpdk_sys as ffi;
 
 use crate::error::*;
 

--- a/rpkt-dpdk/src/mbuf.rs
+++ b/rpkt-dpdk/src/mbuf.rs
@@ -1,6 +1,6 @@
 use std::ptr::NonNull;
 
-use run_dpdk_sys as ffi;
+use rpkt_dpdk_sys as ffi;
 
 use crate::offload::{MbufRxOffload, MbufTxOffload};
 

--- a/rpkt-dpdk/src/mempool.rs
+++ b/rpkt-dpdk/src/mempool.rs
@@ -5,7 +5,7 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 
 use arrayvec::ArrayVec;
-use run_dpdk_sys as ffi;
+use rpkt_dpdk_sys as ffi;
 
 use crate::error::*;
 use crate::Mbuf;

--- a/rpkt-dpdk/src/multiseg.rs
+++ b/rpkt-dpdk/src/multiseg.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::ptr::{null_mut, NonNull};
 
-use run_dpdk_sys as ffi;
+use rpkt_dpdk_sys as ffi;
 
 use crate::offload::{MbufRxOffload, MbufTxOffload};
 use crate::Mempool;

--- a/rpkt-dpdk/src/pbuf.rs
+++ b/rpkt-dpdk/src/pbuf.rs
@@ -1,7 +1,7 @@
 use std::ptr::NonNull;
 
-use run_dpdk_sys as ffi;
-use run_packet::{Buf, PktBuf, PktMut};
+use rpkt_dpdk_sys as ffi;
+use rpkt::{Buf, PktBuf, PktMut};
 
 use crate::multiseg::{data_addr, Mbuf};
 
@@ -155,10 +155,10 @@ impl<T: AsMut<Mbuf> + AsRef<Mbuf>> PktMut for Pbuf<T> {
 #[cfg(test)]
 mod tests {
     use crate::*;
-    use run_packet::ether::*;
-    use run_packet::ipv4::*;
-    use run_packet::udp::*;
-    use run_packet::*;
+    use rpkt::ether::*;
+    use rpkt::ipv4::*;
+    use rpkt::udp::*;
+    use rpkt::*;
 
     #[test]
     fn read_non_contiguous_packet_data() {

--- a/rpkt-dpdk/src/port.rs
+++ b/rpkt-dpdk/src/port.rs
@@ -2,7 +2,7 @@ use std::ffi::CStr;
 use std::sync::Arc;
 
 use arrayvec::ArrayVec;
-use run_dpdk_sys as ffi;
+use rpkt_dpdk_sys as ffi;
 
 use crate::error::*;
 use crate::offload::*;

--- a/rpkt-dpdk/src/service.rs
+++ b/rpkt-dpdk/src/service.rs
@@ -4,7 +4,7 @@ use std::os::raw::{c_char, c_int};
 use std::sync::{Mutex, MutexGuard};
 
 use once_cell::sync::OnceCell;
-use run_dpdk_sys as ffi;
+use rpkt_dpdk_sys as ffi;
 
 use super::error::*;
 use super::lcore::{self, *};

--- a/rpkt-time/Cargo.toml
+++ b/rpkt-time/Cargo.toml
@@ -15,5 +15,6 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ctor = "0.1.25"
+ctor = "0.2.7"
 libc = "0.2"
+minstant = "0.1.7"

--- a/rpkt-time/src/instant.rs
+++ b/rpkt-time/src/instant.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-/// A measurement of a monotonically nondecreasing clock. Similar to
+/// A measurement of a monotonically non-decreasing clock. Similar to
 /// [`std::time::Instant`](std::time::Instant) but is faster and more
 /// accurate with stable TSC.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -52,7 +52,7 @@ impl Instant {
     ///
     /// # Panics
     ///
-    /// Previously we panicked if `earlier` was later than `self`. Currently this method saturates
+    /// Previously we panicked if `earlier` was later than `self`. Currently, this method saturates
     /// to follow the behavior of the standard library. Future versions may reintroduce the panic
     /// in some circumstances.
     ///
@@ -167,11 +167,11 @@ impl Instant {
             .map(Instant)
     }
 
-    /// Convert interal clocking counter into a UNIX timestamp represented as the
-    /// nanoseconds elapsed from [UNIX_EPOCH](std::time::UNIX_EPOCH).
+    /// Convert internal clocking counter into a UNIX timestamp represented as the
+    /// nanoseconds elapsed from [UNIX_EPOCH](UNIX_EPOCH).
     ///
-    /// [`Anchor`](crate::Anchor) contains the necessary calibration data for conversion.
-    /// Typically, initializing an [`Anchor`](crate::Anchor) takes about 50 nano seconds, so
+    /// [`Anchor`](Anchor) contains the necessary calibration data for conversion.
+    /// Typically, initializing an [`Anchor`](Anchor) takes about 50 nanoseconds, so
     /// try to reuse it for a batch of `Instant`.
     ///
     /// # Examples
@@ -239,7 +239,7 @@ impl Sub<Instant> for Instant {
     ///
     /// # Panics
     ///
-    /// Previously we panicked if `other` was later than `self`. Currently this method saturates
+    /// Previously we panicked if `other` was later than `self`. Currently, this method saturates
     /// to follow the behavior of the standard library. Future versions may reintroduce the panic
     /// in some circumstances.
     #[inline]
@@ -256,7 +256,7 @@ impl std::fmt::Debug for Instant {
 
 /// An anchor which can be used to convert internal clocking counter into system timestamp.
 ///
-/// *[See also the `Instant::as_unix_nanos()`](crate::Instant::as_unix_nanos).*
+/// *[See also the `Instant::as_unix_nanos()`](Instant::as_unix_nanos).*
 #[derive(Copy, Clone)]
 pub struct Anchor {
     unix_time_ns: u64,

--- a/rpkt-time/src/instant.rs
+++ b/rpkt-time/src/instant.rs
@@ -21,9 +21,9 @@ impl Instant {
     /// 
     /// # Examples
     /// ```
-    /// use rdtsc_time::Instant;
+    /// use rpkt_time::Instant;
     /// 
-    /// let ddl = Instant::now().raw().checked_add(rdtsc_time::cycles_per_sec()).unwrap();
+    /// let ddl = Instant::now().raw().checked_add(rpkt_time::cycles_per_sec()).unwrap();
     /// while Instant::now().raw() <= ddl {}
     /// 
     /// println!("1s has passed");

--- a/rpkt-time/src/lib.rs
+++ b/rpkt-time/src/lib.rs
@@ -1,21 +1,21 @@
-/// This crate provides an alternative approach to the time crate of the stardard library.
+/// This crate provides an alternative approach to the time crate of the standard library.
 /// It relies on the tsc registers to get the current time instant in a faster and more accurate
-/// fasihon.
+/// fashion.
 ///
-/// Note that this library does has the following limitations:
+/// Note that this library does have the following limitations:
 ///
 /// 1. It only works on 32/64 bits Linux systems with stable tsc (see this blog post for more information
 /// about stable tsc: http://oliveryang.net/2015/09/pitfalls-of-TSC-usage/).
 ///
 /// 2. When this crate is loaded, it will check whether the system has stable tsc.
 /// If it does not detect tsc, it will report `false` through the `tsc_stable()` method.
-/// Any usage of this crate is strictly forbidended without stable tsc, as the APIs of this
-/// crate may report errorneous time result.
+/// Any usage of this crate is strictly forbidden without stable tsc, as the APIs of this
+/// crate may report erroneous time result.
 ///
 /// 3. When initializing this library, it may cause a panic if it fails to read the sysfs file or
 /// parse the file read result.
 ///
-/// Some of the code is taken from minstant library, but remove some unncessary
+/// Some of the code is taken from minstant library, but remove some unnecessary
 /// code path for performance.
 
 #[cfg(all(target_os = "linux", any(target_arch = "x86", target_arch = "x86_64")))]
@@ -44,7 +44,7 @@ pub fn tsc_stable() -> bool {
 }
 
 #[cfg(all(target_os = "linux", any(target_arch = "x86", target_arch = "x86_64")))]
-/// Return the number of CPU cycles of 1 second. It can be used to caclculate future tsc
+/// Return the number of CPU cycles of 1 second. It can be used to calculate future tsc
 /// counter value after a fixed time interval.
 /// 
 /// Note that this method may return 0 if it is not running on systems with stable tsc.

--- a/rpkt-time/src/lib.rs
+++ b/rpkt-time/src/lib.rs
@@ -35,9 +35,9 @@ mod tsc;
 ///
 /// # Examples
 /// ```
-/// use rdtsc_time;
+/// use rpkt_time;
 ///
-/// assert!(rdtsc_time::tsc_stable());
+/// assert!(rpkt_time::tsc_stable());
 /// ```
 pub fn tsc_stable() -> bool {
     tsc::tsc_stable()
@@ -51,9 +51,9 @@ pub fn tsc_stable() -> bool {
 /// 
 /// # Examples
 /// ```
-/// use rdtsc_time::Instant;
+/// use rpkt_time::Instant;
 ///
-/// let ddl = Instant::now().raw().checked_add(rdtsc_time::cycles_per_sec()).unwrap();
+/// let ddl = Instant::now().raw().checked_add(rpkt_time::cycles_per_sec()).unwrap();
 /// while Instant::now().raw() <= ddl {}
 ///
 /// println!("1s has passed");

--- a/rpkt-time/src/tsc.rs
+++ b/rpkt-time/src/tsc.rs
@@ -86,7 +86,7 @@ fn measure_fraq(precision: f64, repeat: u64) -> Option<(f64, u64, Instant, u64)>
         if diff / (tsc2 - tsc1) as f64 <= precision {
             // we get a stable measurement
             let nanos_per_cycle = (t2 - t1).as_nanos() as f64 / (tsc2 - tsc1) as f64;
-            let cycles_per_sec = (1_000_000_000 as f64 / nanos_per_cycle) as u64;
+            let cycles_per_sec = (1_000_000_000f64 / nanos_per_cycle) as u64;
             return Some((nanos_per_cycle, cycles_per_sec, t2, tsc2));
         }
 
@@ -121,7 +121,7 @@ unsafe fn module_init() {
         Some(measure_fraq(PRECISION, 50).unwrap())
     } else {
         // If we can't determine whether tsc is stable from the sysfs, we will
-        // perform a manual check by meausing the CPU fraquency at each core and comparing
+        // perform a manual check by measuring the CPU frequency at each core and comparing
         // the measurement results to see whether they are all synchronized.
         measure_fraq(PRECISION, 50).and_then(
             |(nanos_per_cycle, cycles_per_sec, ref_time, ref_tsc)| {

--- a/rpkt/Cargo.toml
+++ b/rpkt/Cargo.toml
@@ -15,8 +15,8 @@ license.workspace = true
 [dependencies]
 byteorder = "1"
 bytes = "1"
-smoltcp = "0.8"
+smoltcp = "0.8.2"
 
 [dev-dependencies]
-smoltcp = "0.8"
-pnet = "0.31.0"
+smoltcp = "0.8.2"
+pnet = "0.34.0"

--- a/rpkt/src/icmpv6/ndp/option.rs
+++ b/rpkt/src/icmpv6/ndp/option.rs
@@ -457,7 +457,7 @@ impl<'a> NdpOptionWriter<'a> {
         let (buf, remaining) = std::mem::replace(&mut self.buf, &mut []).split_at_mut(32);
         self.buf = remaining;
 
-        let mut opt = NdpOptionPrefixInfo { buf };
+        let opt = NdpOptionPrefixInfo { buf };
         (&mut opt.buf[2..]).fill(0);
 
         opt
@@ -473,14 +473,14 @@ impl<'a> NdpOptionWriter<'a> {
         let (buf, remaining) = std::mem::replace(&mut self.buf, &mut []).split_at_mut(8);
         self.buf = remaining;
 
-        let mut opt = NdpOptionRedirectedHdr { buf };
+        let opt = NdpOptionRedirectedHdr { buf };
         (&mut opt.buf[2..]).fill(0);
 
         opt
     }
 
     #[inline]
-    pub fn mtu(&mut self, opt_len: usize) -> NdpOptionMtu<&'a mut [u8]> {
+    pub fn mtu(&mut self, _opt_len: usize) -> NdpOptionMtu<&'a mut [u8]> {
         assert!(self.buf.len() > 8);
 
         self.buf[0] = MTU;

--- a/rpkt/src/ipv4/header.rs
+++ b/rpkt/src/ipv4/header.rs
@@ -218,7 +218,7 @@ impl<T: AsMut<[u8]>> Ipv4Header<T> {
 
     #[inline]
     pub fn set_frag_offset(&mut self, value: u16) {
-        assert!(value & 0x07 == 0, "invalid fragment offset: {}", value);
+        assert_eq!(value & 0x07, 0, "invalid fragment offset: {}", value);
         let data = flag_fragoff_mut(self.buf.as_mut());
         let raw = (NetworkEndian::read_u16(data) & 0xe000) | (value >> 3);
         NetworkEndian::write_u16(data, raw);

--- a/rpkt/src/ipv6/extentions/routing.rs
+++ b/rpkt/src/ipv6/extentions/routing.rs
@@ -294,10 +294,10 @@ impl<T: Buf> RoutingPacket<T> {
                     buf: self.buf.chunk(),
                 };
                 let addr_buf_len_without_padding = addr_buf_len.checked_sub(tmp_header.pad())?;
-                let last_addr_len = (16 as usize).checked_sub(tmp_header.compr_e())?;
+                let last_addr_len = 16usize.checked_sub(tmp_header.compr_e())?;
                 let len_except_the_last =
                     addr_buf_len_without_padding.checked_sub(last_addr_len)?;
-                let first_addr_len = (16 as usize).checked_sub(tmp_header.compr_i())?;
+                let first_addr_len = 16usize.checked_sub(tmp_header.compr_i())?;
 
                 if len_except_the_last % first_addr_len == 0
                     && tmp_header.segments_left() <= tmp_header.total_addrs()
@@ -378,10 +378,10 @@ impl<T: PktMut> RoutingPacket<T> {
                     buf: self.buf.chunk(),
                 };
                 let addr_buf_len_without_padding = addr_buf_len.checked_sub(tmp_header.pad())?;
-                let last_addr_len = (16 as usize).checked_sub(tmp_header.compr_e())?;
+                let last_addr_len = 16usize.checked_sub(tmp_header.compr_e())?;
                 let len_except_the_last =
                     addr_buf_len_without_padding.checked_sub(last_addr_len)?;
-                let first_addr_len = (16 as usize).checked_sub(tmp_header.compr_i())?;
+                let first_addr_len = 16usize.checked_sub(tmp_header.compr_i())?;
 
                 if len_except_the_last % first_addr_len == 0
                     && tmp_header.segments_left() <= tmp_header.total_addrs()


### PR DESCRIPTION
 * Change the way how DPDK version is checked, as bindings doesn't expose anything that was changed since DPDK 21.11
 * Fix package naming
 * Fix some tests/examples to reference correct package names
 * Update some of the dependencies to their latest version
 * Do `options_bytes_mut().copy_from_slice` instead of `set_options_bytes` in examples/checksum_offload_tx (seems that set_options_bytes were removed long time ago, but example was never fixed)