### PR TITLE
feat(rpkt-dpdk/mbuf): add into_raw API to extract raw pointer from Mbuf

### DIFF
--- a/rpkt-dpdk/src/mbuf.rs
+++ b/rpkt-dpdk/src/mbuf.rs
@@ -150,6 +150,11 @@ impl Mbuf {
             ptr: NonNull::new_unchecked(ptr),
         }
     }
+
+    #[inline]
+    pub unsafe fn into_raw(self) -> *mut ffi::rte_mbuf {
+        self.ptr.as_ptr()
+    }
 }
 
 impl Drop for Mbuf {


### PR DESCRIPTION
Added into_raw() to retrieve *mut rte_mbuf from Mbuf. This complements from_raw(), enabling round-trip FFI interop.