### PR TITLE
feat(rpkt-dpdk): add new feature `rpkt-eval` for evalulation

### DIFF
--- a/rpkt-dpdk/Cargo.toml
+++ b/rpkt-dpdk/Cargo.toml
@@ -18,6 +18,10 @@ arrayvec = "0.7.4"
 once_cell = "1.9.0"
 rpkt = {path = "../rpkt", package = "rpkt"}
 
+[features]
+default = []
+rpkt-eval = []
+
 [build-dependencies]
 version-compare = "0.1.1"
 bindgen = "0.69.4"

--- a/rpkt-dpdk/src/mbuf.rs
+++ b/rpkt-dpdk/src/mbuf.rs
@@ -132,6 +132,13 @@ impl Mbuf {
     }
 
     #[inline]
+    #[cfg(feature = "rpkt-eval")]
+    pub const unsafe fn as_mut_ptr(&mut self) -> *mut ffi::rte_mbuf {
+        self.ptr.as_ptr()
+    }
+
+    #[inline]
+    #[cfg(not(feature = "rpkt-eval"))]
     pub(crate) const unsafe fn as_mut_ptr(&mut self) -> *mut ffi::rte_mbuf {
         self.ptr.as_ptr()
     }


### PR DESCRIPTION
1. expose rpkt_dpdk::Mbuf::as_mut_ptr to external crates (e.g netbricks).